### PR TITLE
Patch PoC to work with observer API as merged into PHP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Observer PHP 8 Extension
 
-This is a PoC PHP 8 extension that demonstrates the instrumentation API.
-
-First compile PHP with the [instrumentation feature](https://github.com/SammyK/php-src/tree/php-8-instrumentation-hooks). Then compile this extension.
+This is a PHP 8 extension that demonstrates the observer API.
 
 ```bash
 $ phpize \
@@ -11,14 +9,26 @@ $ phpize \
     && make
 $ php -dextension=$(pwd)/modules/observer.so --ri=observer
 ```
-When INI setting `observer.instrument=1`, the observer extension will emit a message before and after every function call.
+When INI setting `observer.instrument=1`, the observer extension will emit a message before and after every user land function call.
 
+Create a file called `foo.php` with the following contents
+```php
+<?php
+
+function foo() : int {
+    return 42;
+}
+
+var_dump(foo());
+```
+
+Execute via
 ```bash
 $ /path/to/sapi/cli/php \
     -d extension=$(pwd)/modules/observer.so \
     -d observer.instrument=1 \
-    -r "var_dump(42);"
-[BEGIN var_dump()]
+    foo.php
+[BEGIN foo()]
+[END foo(): int]
 int(42)
-[END var_dump()]
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Observer PHP 8 Extension
 
-This is a PHP 8 extension that demonstrates the observer API.
+This is a PoC PHP 8 extension that demonstrates the observer API.
 
 ```bash
 $ phpize \

--- a/README.md
+++ b/README.md
@@ -11,23 +11,12 @@ $ php -dextension=$(pwd)/modules/observer.so --ri=observer
 ```
 When INI setting `observer.instrument=1`, the observer extension will emit a message before and after every user land function call.
 
-Create a file called `foo.php` with the following contents
-```php
-<?php
-
-function foo() : int {
-    return 42;
-}
-
-var_dump(foo());
-```
-
 Execute via
 ```bash
 $ /path/to/sapi/cli/php \
     -d extension=$(pwd)/modules/observer.so \
     -d observer.instrument=1 \
-    foo.php
+    -r "function foo() {return 42;} var_dump(foo());"
 [BEGIN foo()]
 [END foo(): int]
 int(42)

--- a/observer.c
+++ b/observer.c
@@ -10,19 +10,19 @@
 ZEND_DECLARE_MODULE_GLOBALS(observer)
 
 static void observer_begin(zend_execute_data *execute_data) {
-    php_printf("[BEGIN %s()]\n", ZSTR_VAL(execute_data->func->common.function_name));
+	php_printf("[BEGIN %s()]\n", ZSTR_VAL(execute_data->func->common.function_name));
 }
 
 static void observer_end(zend_execute_data *execute_data, zval *return_value) {
-    php_printf("[END %s(): %s]\n", ZSTR_VAL(execute_data->func->common.function_name), return_value ? zend_zval_type_name(return_value) : "null");
+	php_printf("[END %s(): %s]\n", ZSTR_VAL(execute_data->func->common.function_name), return_value ? zend_zval_type_name(return_value) : "null");
 }
 
 // Runs once per zend_function on its first call
 static zend_observer_fcall_handlers observer_instrument(zend_execute_data *execute_data) {
 	zend_observer_fcall_handlers handlers = {NULL, NULL};
 	if (OBSERVER_G(instrument) == 0 ||
-        !execute_data->func ||
-        !execute_data->func->common.function_name) {
+		!execute_data->func ||
+		!execute_data->func->common.function_name) {
 		return handlers; // I have no handlers for this function
 	}
 	handlers.begin = observer_begin;

--- a/observer.c
+++ b/observer.c
@@ -10,36 +10,19 @@
 ZEND_DECLARE_MODULE_GLOBALS(observer)
 
 static void observer_begin(zend_execute_data *execute_data) {
-    php_printf("BEGIN ");
-	if (execute_data->func && execute_data->func->common.function_name) {
-		if (execute_data->func->common.scope) {
-			php_printf("<%s::%s>\n", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name));
-		} else {
-			php_printf("<%s>\n", ZSTR_VAL(execute_data->func->common.function_name));
-		}
-	} else {
-		php_printf("<file '%s'>\n", ZSTR_VAL(execute_data->func->op_array.filename));
-	}
+    php_printf("[BEGIN %s()]\n", ZSTR_VAL(execute_data->func->common.function_name));
 }
 
 static void observer_end(zend_execute_data *execute_data, zval *return_value) {
-    php_printf("END ");
-	if (execute_data->func && execute_data->func->common.function_name) {
-		if (execute_data->func->common.scope) {
-			php_printf("<%s::%s>\n", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name));
-		} else {
-			php_printf("<%s>\n", ZSTR_VAL(execute_data->func->common.function_name));
-		}
-	} else {
-		php_printf("<file '%s'>\n", ZSTR_VAL(execute_data->func->op_array.filename));
-	}
+    php_printf("[END %s(): %s]\n", ZSTR_VAL(execute_data->func->common.function_name), return_value ? zend_zval_type_name(return_value) : "null");
 }
 
 // Runs once per zend_function on its first call
 static zend_observer_fcall_handlers observer_instrument(zend_execute_data *execute_data) {
 	zend_observer_fcall_handlers handlers = {NULL, NULL};
-    // if (OBSERVER_G(instrument) == 0 || !execute_data->func->common.function_name) {
-    if (OBSERVER_G(instrument) == 0) {
+	if (OBSERVER_G(instrument) == 0 ||
+        !execute_data->func ||
+        !execute_data->func->common.function_name) {
 		return handlers; // I have no handlers for this function
 	}
 	handlers.begin = observer_begin;

--- a/observer.c
+++ b/observer.c
@@ -4,23 +4,42 @@
 
 #include "php.h"
 #include "ext/standard/info.h"
-#include "Zend/zend_instrument.h"
+#include "Zend/zend_observer.h"
 #include "php_observer.h"
 
 ZEND_DECLARE_MODULE_GLOBALS(observer)
 
-static void observer_begin(zend_execute_data *ex) {
-	php_printf("[BEGIN %s()]\n", ZSTR_VAL(ex->func->common.function_name));
+static void observer_begin(zend_execute_data *execute_data) {
+    php_printf("BEGIN ");
+	if (execute_data->func && execute_data->func->common.function_name) {
+		if (execute_data->func->common.scope) {
+			php_printf("<%s::%s>\n", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name));
+		} else {
+			php_printf("<%s>\n", ZSTR_VAL(execute_data->func->common.function_name));
+		}
+	} else {
+		php_printf("<file '%s'>\n", ZSTR_VAL(execute_data->func->op_array.filename));
+	}
 }
 
-static void observer_end(zend_execute_data *ex, zval *return_value) {
-	php_printf("[END %s(): %s]\n", ZSTR_VAL(ex->func->common.function_name), zend_zval_type_name(return_value));
+static void observer_end(zend_execute_data *execute_data, zval *return_value) {
+    php_printf("END ");
+	if (execute_data->func && execute_data->func->common.function_name) {
+		if (execute_data->func->common.scope) {
+			php_printf("<%s::%s>\n", ZSTR_VAL(execute_data->func->common.scope->name), ZSTR_VAL(execute_data->func->common.function_name));
+		} else {
+			php_printf("<%s>\n", ZSTR_VAL(execute_data->func->common.function_name));
+		}
+	} else {
+		php_printf("<file '%s'>\n", ZSTR_VAL(execute_data->func->op_array.filename));
+	}
 }
 
 // Runs once per zend_function on its first call
-static zend_instrument_fcall observer_instrument(zend_function *func) {
-	zend_instrument_fcall handlers = {NULL, NULL};
-	if (OBSERVER_G(instrument) == 0 || !func->common.function_name) {
+static zend_observer_fcall_handlers observer_instrument(zend_execute_data *execute_data) {
+	zend_observer_fcall_handlers handlers = {NULL, NULL};
+    // if (OBSERVER_G(instrument) == 0 || !execute_data->func->common.function_name) {
+    if (OBSERVER_G(instrument) == 0) {
 		return handlers; // I have no handlers for this function
 	}
 	handlers.begin = observer_begin;
@@ -41,7 +60,7 @@ static PHP_MINIT_FUNCTION(observer)
 {
 	ZEND_INIT_MODULE_GLOBALS(observer, php_observer_init_globals, NULL);
 	REGISTER_INI_ENTRIES();
-	zend_instrument_fcall_register(observer_instrument);
+	zend_observer_fcall_register(observer_instrument);
 	return SUCCESS;
 }
 

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -13,10 +13,8 @@ function foo() {
 }
 
 var_dump(foo());
-var_dump(array_sum([111, 111, 111]));
 ?>
 --EXPECT--
 [BEGIN foo()]
 [END foo(): int]
 int(42)
-int(333)

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -18,11 +18,5 @@ var_dump(array_sum([111, 111, 111]));
 --EXPECT--
 [BEGIN foo()]
 [END foo(): int]
-[BEGIN var_dump()]
 int(42)
-[END var_dump(): null]
-[BEGIN array_sum()]
-[END array_sum(): int]
-[BEGIN var_dump()]
 int(333)
-[END var_dump(): null]

--- a/tests/bailout_fatal.phpt
+++ b/tests/bailout_fatal.phpt
@@ -19,8 +19,6 @@ echo 'You should not see this.';
 ?>
 --EXPECTF--
 [BEGIN foo()]
-[BEGIN str_repeat()]
 
 Fatal error: Allowed memory size of 2097152 bytes exhausted%s(tried to allocate %d bytes) in %s on line %d
-[END str_repeat(): null]
 [END foo(): null]

--- a/tests/bailout_fatal_userland.phpt
+++ b/tests/bailout_fatal_userland.phpt
@@ -18,8 +18,6 @@ echo 'You should not see this.';
 ?>
 --EXPECTF--
 [BEGIN foo()]
-[BEGIN trigger_error(): bool]
 
 Fatal error: Foo error in %s on line %d
-[END trigger_error()]
 [END foo(): null]

--- a/tests/bailout_internal.phpt
+++ b/tests/bailout_internal.phpt
@@ -19,8 +19,11 @@ echo 'You should not see this.';
 ?>
 --EXPECTF--
 [BEGIN foo()]
-[BEGIN assert()]
 
-Warning: assert(): assert(false) failed in %s on line %d
-[END assert(): null]
+Fatal error: Uncaught AssertionError: assert(false) in %s
+Stack trace:
+#0 %s: assert(false, 'assert(false)')
+#1 %s: foo()
+#2 {main}
+  thrown in %s on line %d
 [END foo(): null]

--- a/tests/bailout_uncaught_exception.phpt
+++ b/tests/bailout_uncaught_exception.phpt
@@ -19,13 +19,7 @@ echo 'You should not see this.';
 ?>
 --EXPECTF--
 [BEGIN foo()]
-[BEGIN __construct()]
-[END __construct(): null]
 [END foo(): null]
-[BEGIN __toString()]
-[BEGIN getTraceAsString()]
-[END getTraceAsString(): string]
-[END __toString(): string]
 
 Fatal error: Uncaught Exception: Foo error in %s:%d
 Stack trace:

--- a/tests/bailout_within_zend_try.phpt
+++ b/tests/bailout_within_zend_try.phpt
@@ -21,8 +21,6 @@ function foo() {
 }
 ?>
 --EXPECT--
-[BEGIN register_shutdown_function()]
-[END register_shutdown_function(): null]
 [BEGIN {closure}()]
 Shutdown
 [BEGIN foo()]

--- a/tests/internal_call_userland.phpt
+++ b/tests/internal_call_userland.phpt
@@ -20,9 +20,6 @@ $doubles = array_map('double', range(1, 10));
 var_dump($doubles);
 ?>
 --EXPECT--
-[BEGIN range()]
-[END range(): array]
-[BEGIN array_map()]
 [BEGIN double()]
 [END double(): int]
 [BEGIN double()]
@@ -43,8 +40,6 @@ var_dump($doubles);
 [END double(): int]
 [BEGIN double()]
 [END double(): int]
-[END array_map(): array]
-[BEGIN var_dump()]
 array(10) {
   [0]=>
   int(2)
@@ -67,4 +62,3 @@ array(10) {
   [9]=>
   int(20)
 }
-[END var_dump(): null]


### PR DESCRIPTION
Hey @SammyK,

I do not know what your plans with this PoC are. Nevertheless I wanted to play with the Observer API in PHP, so I decided to grab your PoC as a starting point and apply any changes necessary to make this work with the current state of the Observer API as per PHP 8.0

Another thing to consider is: when searching for the terms "php8 observer api" this github repository is the first to show up (at least for me) in Google results, so it may help others who are searching for a proof of concept if this repository is up to date.

What do you think?

Kind regards
Florian